### PR TITLE
async is a reserved word: target.cuda(non_blocking=True)

### DIFF
--- a/fastai/core.py
+++ b/fastai/core.py
@@ -34,7 +34,7 @@ def T(a, half=False, cuda=True):
         elif a.dtype in (np.float32, np.float64):
             a = torch.cuda.HalfTensor(a) if half else torch.FloatTensor(a)
         else: raise NotImplementedError(a.dtype)
-    if cuda: a = to_gpu(a, async=True)
+    if cuda: a = to_gpu(a, non_blocking=True)
     return a
 
 def create_variable(x, volatile, requires_grad=False):

--- a/fastai/models/cifar10/main_dxy.py
+++ b/fastai/models/cifar10/main_dxy.py
@@ -176,7 +176,7 @@ def train(train_loader, model, criterion, optimizer, epoch, log):
     data_time.update(time.time() - end)
 
     if args.use_cuda:
-      target = target.cuda(async=True)
+      target = target.cuda(non_blocking=True)
       input = input.cuda()
     input_var = torch.autograd.Variable(input)
     target_var = torch.autograd.Variable(target)

--- a/fastai/models/cifar10/main_dxy.py
+++ b/fastai/models/cifar10/main_dxy.py
@@ -220,7 +220,7 @@ def validate(val_loader, model, criterion, log):
 
   for i, (input, target) in enumerate(val_loader):
     if args.use_cuda:
-      target = target.cuda(async=True)
+      target = target.cuda(non_blocking=True)
       input = input.cuda()
     input_var = torch.autograd.Variable(input, volatile=True)
     target_var = torch.autograd.Variable(target, volatile=True)


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/jantic/DeOldify on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./fastai/core.py:37:32: E999 SyntaxError: invalid syntax
    if cuda: a = to_gpu(a, async=True)
                               ^
./fastai/models/cifar10/main_dxy.py:179:32: E999 SyntaxError: invalid syntax
      target = target.cuda(async=True)
                               ^
2     E999 SyntaxError: invalid syntax
2
```