### PR TITLE
Undefined name: import torch

### DIFF
--- a/fastai/models/cifar10/utils_kuangliu.py
+++ b/fastai/models/cifar10/utils_kuangliu.py
@@ -8,6 +8,7 @@ import sys
 import time
 import math
 
+import torch
 import torch.nn as nn
 import torch.nn.init as init
 


### PR DESCRIPTION
flake8 testing of https://github.com/jantic/DeOldify on Python 3.7.1

$ flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
```
./fastai/models/cifar10/utils_kuangliu.py:17:18: F821 undefined name 'torch'
    dataloader = torch.utils.data.DataLoader(dataset, batch_size=1, shuffle=True, num_workers=2)
                 ^
./fastai/models/cifar10/utils_kuangliu.py:18:12: F821 undefined name 'torch'
    mean = torch.zeros(3)
           ^
./fastai/models/cifar10/utils_kuangliu.py:19:11: F821 undefined name 'torch'
    std = torch.zeros(3)
          ^
3     F821 undefined name 'torch'
3
```