### PR TITLE
Fix a import statement that prevents deoldify functions to be called from other folders

### DIFF
--- a/fasterai/visualize.py
+++ b/fasterai/visualize.py
@@ -7,7 +7,7 @@ from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from fastai.dataset import FilesDataset, ImageData, ModelData, open_image
 from fastai.transforms import Transform, scale_min, tfms_from_stats, inception_stats
 from fastai.transforms import CropType, NoCrop, Denormalize, Scale
-from fasterai.transforms import BlackAndWhiteTransform
+from .transforms import BlackAndWhiteTransform
 from .training import GenResult, CriticResult, GANTrainer
 from .images import ModelImageSet, EasyTensorImage
 from .generators import GeneratorModule


### PR DESCRIPTION
Hey jantic,

I hope you had a great start into the new year!

I just got myself a CUDA-compatible GPU and found new joy in developing my video colorization project. As part of this, I included DeOldify as a git submodule and detected this single line of code that prevents me from calling fasterai methods from outside of the repository.

That would be it - cheers!