### PR TITLE
add ffmpeg to Dockerfile for youtube-dl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ From nvcr.io/nvidia/pytorch:19.04-py3
 
 RUN apt-get -y update
 
-RUN apt-get install -y python3-pip software-properties-common wget
+RUN apt-get install -y python3-pip software-properties-common wget ffmpeg
 
 RUN add-apt-repository ppa:git-core/ppa
 


### PR DESCRIPTION
I've tried to use the Docker version, it fails on youtube-dl with an error requesting ffmpeg. With ffmpeg works fine.