### PR TITLE
Remove duplicated wget

### DIFF
--- a/ImageColorizerColab.ipynb
+++ b/ImageColorizerColab.ipynb
@@ -141,7 +141,7 @@
    "outputs": [],
    "source": [
     "!mkdir 'models'\n",
-    "!wget wget https://www.dropbox.com/s/zkehq1uwahhbc2o/ColorizeArtistic_gen.pth?dl=0 -O ./models/ColorizeArtistic_gen.pth"
+    "!wget https://www.dropbox.com/s/zkehq1uwahhbc2o/ColorizeArtistic_gen.pth?dl=0 -O ./models/ColorizeArtistic_gen.pth"
    ]
   },
   {


### PR DESCRIPTION
This duplicated wget was causing a warning
when running the Colab notebook.