### PR TITLE
Use a more reliable way to create directories

### DIFF
--- a/app_utils.py
+++ b/app_utils.py
@@ -106,7 +106,7 @@ def clean_all(files):
 
 
 def create_directory(path):
-    os.system("mkdir -p %s" % os.path.dirname(path))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
 
 
 def get_model_bin(url, output_path):


### PR DESCRIPTION
Using os.makedirs will raise an exception if
it fails to create the directory, os.system
on the other hand will just print a warning,
thus the application will fail down the road
due missing directories.