### PR TITLE
github: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# See: https://help.github.com/en/articles/about-code-owners
+#
+# Owners will be requested for review when someone opens a pull request.
+*       @jantic @alexandrevicenzi


### PR DESCRIPTION
CODEOWNERS will automatically invite members
for code review.

With branch protection at least one code owner
must approve a PR before it's merged.