### PR TITLE
pypi: setup.py to enable deploy to pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,40 @@
+from setuptools import setup, find_packages
+
+
+def get_description():
+    return "Deep Learning library for colorizing and restoring old images and video"
+
+
+# def get_long_description():
+#     with open("README.md") as f:
+#         return f.read()
+
+
+def get_requirements():
+    with open("requirements.txt") as f:
+        return f.read().splitlines()
+
+
+setup(
+    name="DeOldify",
+    version="0.0.1",
+    packages=find_packages(exclude=["tests"]),
+    url="https://github.com/jantic/DeOldify",
+    license="MIT License",
+    description=get_description(),
+    # long_description=get_long_description(),
+    # long_description_content_type="text/markdown",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Framework :: Jupyter",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    install_requires=get_requirements(),
+    python_requires=">=3.6",
+)


### PR DESCRIPTION
setup.py will allow to deploy DeOldify to
PyPI and make it pip installable.

This patch itself does not deploy to PyPI,
a configuration file is required to deploy
automatically when there's a new release.

For now, it does not include the README into
the description because it will be to hard to
understand on PyPI. Another patch will be
sent to create a description that can
actually fit PyPI.