### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
 - tensorboardX=1.6
 - youtube-dl>=2019.4.17
 - jupyterlab
+- pillow=6.2.1
 - pip:
   - ffmpeg-python==0.1.17
   - opencv-python>=3.3.0.10


### PR DESCRIPTION
The same issue (`PILLOW_VERSION` import error) as #180 when running the first import cell in training notebooks on my VM.
Updated `environment.yml` by adding an older version of Pillow for the conda environment to fix this.
Everything works fine now.