### PR TITLE
Setting output directory properly

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,6 +90,7 @@ if __name__ == '__main__':
 
 
     image_colorizer = get_image_colorizer(artistic=True)
+    image_colorizer.results_dir = Path(results_img_directory)
     
     port = 5000
     host = '0.0.0.0'


### PR DESCRIPTION
Without this fix, `app.py` outputs resaturated images into subfolder of current working dir and Flask fails to send the image in response because filename path passed is wrong.