### PR TITLE
Fixing output path for colorized videos

### DIFF
--- a/app-video.py
+++ b/app-video.py
@@ -79,6 +79,7 @@ if __name__ == '__main__':
     get_model_bin(video_model_url, os.path.join(model_directory, 'ColorizeVideo_gen.pth'))
 
     video_colorizer = get_video_colorizer()
+    video_colorizer.result_folder = Path(results_video_directory)
     
     port = 5000
     host = '0.0.0.0'


### PR DESCRIPTION
Fix similar to one for `app.py`. Now video coloriser writes to subfolder of current work directory and flask can not find the output file.