### PR TITLE
Add accept header for permit all MIME types

### DIFF
--- a/deoldify/visualize.py
+++ b/deoldify/visualize.py
@@ -62,7 +62,7 @@ class ModelImageVisualizer:
         return PIL.Image.open(path).convert('RGB')
 
     def _get_image_from_url(self, url: str) -> Image:
-        response = requests.get(url, timeout=30)
+        response = requests.get(url, timeout=30, headers={'Accept': '*/*;q=0.8'})
         img = PIL.Image.open(BytesIO(response.content)).convert('RGB')
         return img
 


### PR DESCRIPTION
In some cases when trying to request the image url, the host returned `HTTP Error 403: Forbidden`, as this error is not dealt with right away, the `BytesIO` constructor is called with an invalid value, returning a blank byte sequence , then this sequence is passed to the `PIL.Image.open()` function, raise the exception `PIL.UnidentifiedImageError`.

An acceptance header has been added to allow all MIME types, resolving cases of hosts that it is mandatory to define content types.