### PR TITLE
Pin tornado in colab_requirements.txt

### DIFF
--- a/colab_requirements.txt
+++ b/colab_requirements.txt
@@ -6,3 +6,4 @@ youtube-dl>=2019.4.17
 jupyterlab
 opencv-python>=3.3.0.10
 pillow
+tornado~=5.1.0


### PR DESCRIPTION
Google Colab requires `tornado 5.1`, so pin it to that version.