### PR TITLE
Add Open in Kaggle badge

### DIFF
--- a/ColorizeTrainingVideo.ipynb
+++ b/ColorizeTrainingVideo.ipynb
@@ -6,7 +6,6 @@
    "source": [
     "## Video Model Training",
     "\n",
-    "<br></br>",
     "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/jantic/DeOldify/blob/master/ColorizeTrainingVideo.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>"
    ]
   },

--- a/ColorizeTrainingVideo.ipynb
+++ b/ColorizeTrainingVideo.ipynb
@@ -4,7 +4,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Video Model Training"
+    "## Video Model Training",
+    "\n",
+    "<br></br>",
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/jantic/DeOldify/blob/master/ColorizeTrainingVideo.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>"
    ]
   },
   {


### PR DESCRIPTION
This is an example of what adding a Kaggle Badge (that allows for opening the .ipynb as a Kaggle Notebook as seen here https://www.kaggle.com/product-feedback/152480) would look like.

If it makes sense I can submit a further PR adding it to other notebooks in the repo.