### PR TITLE
Remove ffmpeg / no-check-certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN pip install --upgrade pip \
 		numpy==1.16 \
 		scikit-image==0.15.0 \
 		requests==2.21.0 \
-		ffmpeg==1.4 \
 		ffmpeg-python==0.1.17 \
 		youtube-dl>=2019.4.17 \
 		jupyterlab==1.2.4 \
@@ -40,8 +39,8 @@ ADD . /data/
 WORKDIR /data
 
 # force download of file if not provided by local cache
-RUN [[ ! -f /data/models/ColorizeArtistic_gen.pth ]] && wget -O /data/models/ColorizeArtistic_gen.pth https://data.deepai.org/deoldify/ColorizeArtistic_gen.pth
-RUN [[ ! -f /data/models/ColorizeVideo_gen.pth ]] && wget -O /data/models/ColorizeVideo_gen.pth https://data.deepai.org/deoldify/ColorizeVideo_gen.pth
+RUN [[ ! -f /data/models/ColorizeArtistic_gen.pth ]] && wget --no-check-certificate -O /data/models/ColorizeArtistic_gen.pth https://data.deepai.org/deoldify/ColorizeArtistic_gen.pth
+RUN [[ ! -f /data/models/ColorizeVideo_gen.pth ]] && wget --no-check-certificate -O /data/models/ColorizeVideo_gen.pth https://data.deepai.org/deoldify/ColorizeVideo_gen.pth
 
 COPY run_notebook.sh /usr/local/bin/run_notebook
 COPY run_image_api.sh /usr/local/bin/run_image_api


### PR DESCRIPTION
This suffers from the same issue that the jupyter / colab version does with the known ffmpeg problem - so I needed to remove the ffmpeg line, else it gives that ffmpeg.input error when running the docker container for video

Also added --no-check-certificate as the deepai https certificates are showing as expired (for me at least)