### PR TITLE
Make continuing video processing easier

### DIFF
--- a/VideoColorizer.ipynb
+++ b/VideoColorizer.ipynb
@@ -93,6 +93,8 @@
    "source": [
     "#NOTE:  Max is 44 with 11GB video cards.  21 is a good default\n",
     "render_factor=21\n",
+	"#NOTE:  Set this to false if you want to continue an existing job.",
+	"restart=True\n",
     "#NOTE:  Make source_url None to just read from file at ./video/source/[file_name] directly without modification\n",
     "source_url='https://twitter.com/silentmoviegifs/status/1116751583386034176'\n",
     "file_name = 'DogShy1926'\n",
@@ -100,9 +102,9 @@
     "result_path = None\n",
     "\n",
     "if source_url is not None:\n",
-    "    result_path = colorizer.colorize_from_url(source_url, file_name_ext, render_factor=render_factor)\n",
+    "    result_path = colorizer.colorize_from_url(source_url, file_name_ext, render_factor=render_factor, restart=restart)\n",
     "else:\n",
-    "    result_path = colorizer.colorize_from_file_name(file_name_ext, render_factor=render_factor)\n",
+    "    result_path = colorizer.colorize_from_file_name(file_name_ext, render_factor=render_factor, restart=restart)\n",
     "\n",
     "show_video_in_notebook(result_path)"
    ]

--- a/VideoColorizer.ipynb
+++ b/VideoColorizer.ipynb
@@ -93,8 +93,8 @@
    "source": [
     "#NOTE:  Max is 44 with 11GB video cards.  21 is a good default\n",
     "render_factor=21\n",
-	"#NOTE:  Set this to false if you want to continue an existing job.",
-	"restart=True\n",
+	"#NOTE:  Set this to True if you want to continue an existing job.",
+	"resume=False\n",
     "#NOTE:  Make source_url None to just read from file at ./video/source/[file_name] directly without modification\n",
     "source_url='https://twitter.com/silentmoviegifs/status/1116751583386034176'\n",
     "file_name = 'DogShy1926'\n",
@@ -102,9 +102,9 @@
     "result_path = None\n",
     "\n",
     "if source_url is not None:\n",
-    "    result_path = colorizer.colorize_from_url(source_url, file_name_ext, render_factor=render_factor, restart=restart)\n",
+    "    result_path = colorizer.colorize_from_url(source_url, file_name_ext, render_factor=render_factor, resume=resume)\n",
     "else:\n",
-    "    result_path = colorizer.colorize_from_file_name(file_name_ext, render_factor=render_factor, restart=restart)\n",
+    "    result_path = colorizer.colorize_from_file_name(file_name_ext, render_factor=render_factor, resume=resume)\n",
     "\n",
     "show_video_in_notebook(result_path)"
    ]

--- a/VideoColorizerColab.ipynb
+++ b/VideoColorizerColab.ipynb
@@ -236,9 +236,10 @@
     "source_url = '' #@param {type:\"string\"}\n",
     "render_factor = 21  #@param {type: \"slider\", min: 5, max: 40}\n",
     "watermarked = True #@param {type:\"boolean\"}\n",
+	"restart = True #@param {type:\"boolean\"}\n",
     "\n",
-    "if source_url is not None and source_url !='':\n",
-    "    video_path = colorizer.colorize_from_url(source_url, 'video.mp4', render_factor, watermarked=watermarked)\n",
+    "if source_url:\n",
+    "    video_path = colorizer.colorize_from_url(source_url, 'video.mp4', render_factor, watermarked=watermarked, restart=restart)\n",
     "    show_video_in_notebook(video_path)\n",
     "else:\n",
     "    print('Provide a video url and try again.')"

--- a/VideoColorizerColab.ipynb
+++ b/VideoColorizerColab.ipynb
@@ -236,10 +236,10 @@
     "source_url = '' #@param {type:\"string\"}\n",
     "render_factor = 21  #@param {type: \"slider\", min: 5, max: 40}\n",
     "watermarked = True #@param {type:\"boolean\"}\n",
-	"restart = True #@param {type:\"boolean\"}\n",
+	"resume = False #@param {type:\"boolean\"}\n",
     "\n",
     "if source_url:\n",
-    "    video_path = colorizer.colorize_from_url(source_url, 'video.mp4', render_factor, watermarked=watermarked, restart=restart)\n",
+    "    video_path = colorizer.colorize_from_url(source_url, 'video.mp4', render_factor, watermarked=watermarked, resume=resume)\n",
     "    show_video_in_notebook(video_path)\n",
     "else:\n",
     "    print('Provide a video url and try again.')"

--- a/deoldify/visualize.py
+++ b/deoldify/visualize.py
@@ -16,6 +16,10 @@ from IPython.display import Image as ipythonimage
 import cv2
 import logging
 
+
+FRAME_NAME_TEMPLATE = '%08d.jpg'
+
+
 # adapted from https://www.pyimagesearch.com/2016/04/25/watermarking-images-with-opencv-and-python/
 def get_watermarked(pil_image: Image) -> Image:
     try:
@@ -259,7 +263,7 @@ class VideoColorizer:
 
     def _extract_raw_frames(self, source_path: Path):
         bwframes_folder = self.bwframes_root / (source_path.stem)
-        bwframe_path_template = str(bwframes_folder / '%5d.jpg')
+        bwframe_path_template = str(bwframes_folder / FRAME_NAME_TEMPLATE)
         bwframes_folder.mkdir(parents=True, exist_ok=True)
         self._purge_images(bwframes_folder)
 
@@ -306,7 +310,7 @@ class VideoColorizer:
             source_path.name.replace('.mp4', '_no_audio.mp4')
         )
         colorframes_folder = self.colorframes_root / (source_path.stem)
-        colorframes_path_template = str(colorframes_folder / '%5d.jpg')
+        colorframes_path_template = str(colorframes_folder / FRAME_NAME_TEMPLATE)
         colorized_path.parent.mkdir(parents=True, exist_ok=True)
         if colorized_path.exists():
             colorized_path.unlink()

--- a/deoldify/visualize.py
+++ b/deoldify/visualize.py
@@ -264,6 +264,7 @@ class VideoColorizer:
 
     def _extract_raw_frames(self, source_path: Path):
         logging.info("Extracting raw frames")
+
         bwframes_folder = self.bwframes_root / (source_path.stem)
         bwframe_path_template = str(bwframes_folder / FRAME_NAME_TEMPLATE)
         bwframes_folder.mkdir(parents=True, exist_ok=True)
@@ -293,6 +294,7 @@ class VideoColorizer:
         self, source_path: Path, render_factor: int = None, post_process: bool = True,
         watermarked: bool = True, restart: bool = True
     ):
+        logging.info("Processing raw frames")
         colorframes_folder = self.colorframes_root / source_path.stem
         colorframes_folder.mkdir(parents=True, exist_ok=True)
 

--- a/deoldify/visualize.py
+++ b/deoldify/visualize.py
@@ -353,6 +353,7 @@ class VideoColorizer:
         )
 
         try:
+            logging.info('Building video')
             process.run()
         except ffmpeg.Error as e:
             logging.error("ffmpeg error: {0}".format(e), exc_info=True)
@@ -366,13 +367,17 @@ class VideoColorizer:
         result_path = self.result_folder / source_path.name
         if result_path.exists():
             result_path.unlink()
+
         # making copy of non-audio version in case adding back audio doesn't apply or fails.
+        logging.info('Copying...')
         shutil.copyfile(str(colorized_path), str(result_path))
 
         # adding back sound here
         audio_file = Path(str(source_path).replace('.mp4', '.aac'))
         if audio_file.exists():
             audio_file.unlink()
+
+        logging.info('Extracting audio')
 
         os.system(
             'ffmpeg -y -i "'
@@ -386,6 +391,8 @@ class VideoColorizer:
         )
 
         if audio_file.exists():
+            logging.info('Combining')
+
             os.system(
                 'ffmpeg -y -i "'
                 + str(colorized_path)

--- a/deoldify/visualize.py
+++ b/deoldify/visualize.py
@@ -228,6 +228,10 @@ class VideoColorizer:
         for f in glob.glob(pattern):
             os.remove(f)
 
+        completed_file = os.path.join(path, '.completed')
+        if os.path.exists(completed_file):
+            os.remove(completed_file)
+
     def _get_ffmpeg_probe(self, path:Path):
         try:
             probe = ffmpeg.probe(str(path))


### PR DESCRIPTION
1. Increase the number of digits for frames so they sort easily
2. Process frames in alphanumeric order, rather than arbitrary order decided by the filesystem.
3. Add a ~~`restart`~~ `resume` option which won't download the video again, and will skip frames that have already been processed. It doesn't skip the copying or extraction steps though
4. Put some log messages in so that you can see what step it's up to.

So if you're worried about running out of time on colab, you can tar up the dest images every couple of hours and move them over to drive, restart the session, copy them back in and continue.