### PR TITLE
Added support for resume and lots of other improvements

### DIFF
--- a/VideoColorizer.ipynb
+++ b/VideoColorizer.ipynb
@@ -6,10 +6,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#NOTE:  This must be the first call in order to work properly!\n",
+    "# NOTE: NUMEXPR_MAX_THREADS can default to lower than your maximum, use the below to set accordingly.\n",
+    "# import os\n",
+    "# os.environ['NUMEXPR_MAX_THREADS'] = '10'\n",
+    "\n",
+    "# NOTE: This must be the first call in order to work properly!\n",
     "from deoldify import device\n",
     "from deoldify.device_id import DeviceId\n",
-    "#choices:  CPU, GPU0...GPU7\n",
+    "\n",
+    "#NOTE: choices are CPU, GPU0...GPU7\n",
     "device.set(device=DeviceId.GPU0)"
    ]
   },
@@ -21,8 +26,9 @@
    "source": [
     "from deoldify.visualize import *\n",
     "plt.style.use('dark_background')\n",
+    "\n",
     "import warnings\n",
-    "warnings.filterwarnings(\"ignore\", category=UserWarning, message=\".*?Your .*? set is empty.*?\")"
+    "warnings.filterwarnings('ignore', category=UserWarning, message='.*?Your .*? set is empty.*?')"
    ]
   },
   {
@@ -91,20 +97,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#NOTE:  Max is 44 with 11GB video cards.  21 is a good default\n",
-    "render_factor=21\n",
-    "#NOTE:  Make source_url None to just read from file at ./video/source/[file_name] directly without modification\n",
-    "source_url='https://twitter.com/silentmoviegifs/status/1116751583386034176'\n",
-    "file_name = 'DogShy1926'\n",
-    "file_name_ext = file_name + '.mp4'\n",
-    "result_path = None\n",
+    "# NOTE: Max is 44 with 11GB video cards, 21 is a good default.\n",
+    "render_factor = 21\n",
     "\n",
-    "if source_url is not None:\n",
-    "    result_path = colorizer.colorize_from_url(source_url, file_name_ext, render_factor=render_factor)\n",
-    "else:\n",
-    "    result_path = colorizer.colorize_from_file_name(file_name_ext, render_factor=render_factor)\n",
+    "# NOTE: For local URIs, just read the source file from ./video/source/[file_name] without modification\n",
+    "source_uri = 'modern.mp4'\n",
+    "result_path = colorizer.colorize_from_uri(source_uri, render_factor=render_factor, watermarked=False, resume=True)\n",
     "\n",
-    "show_video_in_notebook(result_path)"
+    "show_video_in_notebook(result_path)\n"
    ]
   },
   {
@@ -120,8 +120,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i in range(10,45,2):\n",
-    "    colorizer.vis.plot_transformed_image('video/bwframes/' + file_name + '/00001.jpg', render_factor=i, display_render_factor=True, figsize=(8,8))"
+    "for i in range(10, 45, 2):\n",
+    "    colorizer.vis.plot_transformed_image('video/bwframes/' + file_name + '/00001.jpg', render_factor=i,\n",
+    "                                         display_render_factor=True, figsize=(8, 8))"
    ]
   },
   {

--- a/VideoColorizer.ipynb
+++ b/VideoColorizer.ipynb
@@ -28,7 +28,13 @@
     "plt.style.use('dark_background')\n",
     "\n",
     "import warnings\n",
-    "warnings.filterwarnings('ignore', category=UserWarning, message='.*?Your .*? set is empty.*?')"
+    "warnings.filterwarnings('ignore', category=UserWarning, message='.*?Your .*? set is empty.*?')\n",
+    "\n",
+    "# NOTE: Torchvision 0.13 added an upgrade that allows to use pre-trained models on different weights,\n",
+    "#       the 2 lines below suppresses the resulting warning messages until such a time when we use a\n",
+    "#       \"compatible\" fast.ai version.\n",
+    "warnings.filterwarnings('ignore', category=UserWarning, message='.*?parameter \\'pretrained\\' is deprecated since 0.13.*?')\n",
+    "warnings.filterwarnings('ignore', category=UserWarning, message='.*?\\'weights\\' are deprecated since 0.13.*?')"
    ]
   },
   {

--- a/deoldify/__init__.py
+++ b/deoldify/__init__.py
@@ -1,7 +1,9 @@
 import sys
 import logging
-logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
-logging.getLogger().setLevel(logging.INFO)
+logging.basicConfig(stream=sys.stdout,
+                    format='%(asctime)s %(message)s',
+                    datefmt='%d/%m/%Y %H:%M:%S %z',
+                    level=logging.INFO)
 
 from deoldify._device import _Device
 

--- a/deoldify/filters.py
+++ b/deoldify/filters.py
@@ -48,7 +48,6 @@ class BaseFilter(IFilter):
         return result
 
     def _model_process(self, orig: PilImage, sz: int) -> PilImage:
-
         model_image = self._get_model_ready_image(orig, sz)
         x = pil2tensor(model_image, np.float32)
         x = x.to(self.device)
@@ -135,7 +134,7 @@ class MasterFilter(BaseFilter):
 
         render_factor = self.render_factor if render_factor is None else render_factor
 
-        for filter in self.filters:
-            filtered_image = filter.filter(orig_image, filtered_image, render_factor, post_process)
+        for a_filter in self.filters:
+            filtered_image = a_filter.filter(orig_image, filtered_image, render_factor, post_process)
 
         return filtered_image

--- a/deoldify/visualize.py
+++ b/deoldify/visualize.py
@@ -1,414 +1,519 @@
+import logging
+import base64
+from io import BytesIO
+from urllib.parse import urlparse
+
+import cv2
+import ffmpeg
+import yt_dlp as youtube_dl
+import requests
+
 from fastai.core import *
 from fastai.vision import *
 from matplotlib.axes import Axes
 from .filters import IFilter, MasterFilter, ColorizerFilter
 from .generators import gen_inference_deep, gen_inference_wide
 from PIL import Image
-import ffmpeg
-import yt_dlp as youtube_dl
-import gc
-import requests
-from io import BytesIO
-import base64
-from IPython import display as ipythondisplay
+from IPython import display as ipython_display
 from IPython.display import HTML
-from IPython.display import Image as ipythonimage
-import cv2
-import logging
+from IPython.display import Image as IpythonImage
+
 
 # adapted from https://www.pyimagesearch.com/2016/04/25/watermarking-images-with-opencv-and-python/
 def get_watermarked(pil_image: Image) -> Image:
+
     try:
         image = cv2.cvtColor(np.array(pil_image), cv2.COLOR_RGB2BGR)
         (h, w) = image.shape[:2]
-        image = np.dstack([image, np.ones((h, w), dtype="uint8") * 255])
+        image = np.dstack([image, np.ones((h, w), dtype='uint8') * 255])
         pct = 0.05
-        full_watermark = cv2.imread(
-            './resource_images/watermark.png', cv2.IMREAD_UNCHANGED
-        )
+        full_watermark = cv2.imread('./resource_images/watermark.png', cv2.IMREAD_UNCHANGED)
         (fwH, fwW) = full_watermark.shape[:2]
-        wH = int(pct * h)
-        wW = int((pct * h / fwH) * fwW)
-        watermark = cv2.resize(full_watermark, (wH, wW), interpolation=cv2.INTER_AREA)
-        overlay = np.zeros((h, w, 4), dtype="uint8")
-        (wH, wW) = watermark.shape[:2]
-        overlay[h - wH - 10 : h - 10, 10 : 10 + wW] = watermark
+        w_height = int(pct * h)
+        w_width = int((pct * h / fwH) * fwW)
+
+        watermark = cv2.resize(full_watermark, (w_height, w_width), interpolation=cv2.INTER_AREA)
+        overlay = np.zeros((h, w, 4), dtype='uint8')
+        (w_height, w_width) = watermark.shape[:2]
+        overlay[h - w_height - 10: h - 10, 10: 10 + w_width] = watermark
+
         # blend the two images together using transparent overlays
         output = image.copy()
         cv2.addWeighted(overlay, 0.5, output, 1.0, 0, output)
         rgb_image = cv2.cvtColor(output, cv2.COLOR_BGR2RGB)
+
         final_image = Image.fromarray(rgb_image)
         return final_image
-    except:
+
+    except Exception:
         # Don't want this to crash everything, so let's just not watermark the image for now.
         return pil_image
 
 
 class ModelImageVisualizer:
-    def __init__(self, filter: IFilter, results_dir: str = None):
-        self.filter = filter
+    def __init__(self,
+                 filter_: IFilter,
+                 results_dir: str = None):
+
+        self.filter = filter_
         self.results_dir = None if results_dir is None else Path(results_dir)
         self.results_dir.mkdir(parents=True, exist_ok=True)
 
     def _clean_mem(self):
         torch.cuda.empty_cache()
-        # gc.collect()
 
     def _open_pil_image(self, path: Path) -> Image:
         return PIL.Image.open(path).convert('RGB')
 
     def _get_image_from_url(self, url: str) -> Image:
-        response = requests.get(url, timeout=30, headers={'user-agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36'})
-        img = PIL.Image.open(BytesIO(response.content)).convert('RGB')
+        response = requests.get(url,
+                                timeout=30,
+                                headers={'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36'}
+                                )
+        response_bytes = BytesIO(response.content)
+        img = PIL.Image.open(response_bytes).convert('RGB')
         return img
 
-    def plot_transformed_image_from_url(
-        self,
-        url: str,
-        path: str = 'test_images/image.png',
-        results_dir:Path = None,
-        figsize: Tuple[int, int] = (20, 20),
-        render_factor: int = None,
-        
-        display_render_factor: bool = False,
-        compare: bool = False,
-        post_process: bool = True,
-        watermarked: bool = True,
-    ) -> Path:
+    def plot_transformed_image_from_url(self,
+                                        url: str,
+                                        path: str = 'test_images/image.png',
+                                        results_dir: Path = None,
+                                        figure_size: Tuple[int, int] = (20, 20),
+                                        render_factor: int = None,
+                                        display_render_factor: bool = False,
+                                        compare: bool = False,
+                                        post_process: bool = True,
+                                        watermarked: bool = True) -> Path:
+
         img = self._get_image_from_url(url)
         img.save(path)
-        return self.plot_transformed_image(
-            path=path,
-            results_dir=results_dir,
-            figsize=figsize,
-            render_factor=render_factor,
-            display_render_factor=display_render_factor,
-            compare=compare,
-            post_process = post_process,
-            watermarked=watermarked,
-        )
 
-    def plot_transformed_image(
-        self,
-        path: str,
-        results_dir:Path = None,
-        figsize: Tuple[int, int] = (20, 20),
-        render_factor: int = None,
-        display_render_factor: bool = False,
-        compare: bool = False,
-        post_process: bool = True,
-        watermarked: bool = True,
-    ) -> Path:
-        path = Path(path)
+        return self.plot_transformed_image(path=path,
+                                           results_dir=results_dir,
+                                           figure_size=figure_size,
+                                           render_factor=render_factor,
+                                           display_render_factor=display_render_factor,
+                                           compare=compare,
+                                           post_process=post_process,
+                                           watermarked=watermarked)
+
+    def plot_transformed_image(self,
+                               path: str,
+                               results_dir: Path = None,
+                               figure_size: Tuple[int, int] = (20, 20),
+                               render_factor: int = None,
+                               display_render_factor: bool = False,
+                               compare: bool = False,
+                               post_process: bool = True,
+                               watermarked: bool = True) -> Path:
+
+        parsed_path = Path(path)
+
         if results_dir is None:
             results_dir = Path(self.results_dir)
-        result = self.get_transformed_image(
-            path, render_factor, post_process=post_process,watermarked=watermarked
-        )
-        orig = self._open_pil_image(path)
-        if compare:
-            self._plot_comparison(
-                figsize, render_factor, display_render_factor, orig, result
-            )
-        else:
-            self._plot_solo(figsize, render_factor, display_render_factor, result)
 
-        orig.close()
-        result_path = self._save_result_image(path, result, results_dir=results_dir)
-        result.close()
+        result_image = self.get_transformed_image(parsed_path,
+                                                  render_factor,
+                                                  post_process=post_process,
+                                                  watermarked=watermarked)
+
+        original_image = self._open_pil_image(parsed_path)
+
+        if compare:
+            self._plot_comparison(figure_size,
+                                  render_factor,
+                                  display_render_factor,
+                                  original_image,
+                                  result_image)
+        else:
+            self._plot_solo(figure_size,
+                            render_factor,
+                            display_render_factor,
+                            result_image)
+
+        original_image.close()
+        result_path = self._save_result_image(parsed_path, result_image, results_dir=results_dir)
+        result_image.close()
+
         return result_path
 
-    def _plot_comparison(
-        self,
-        figsize: Tuple[int, int],
-        render_factor: int,
-        display_render_factor: bool,
-        orig: Image,
-        result: Image,
-    ):
-        fig, axes = plt.subplots(1, 2, figsize=figsize)
+    def _plot_comparison(self,
+                         figure_size: Tuple[int, int],
+                         render_factor: int,
+                         display_render_factor: bool,
+                         orig: Image,
+                         result: Image):
+        fig, axes = plt.subplots(1, 2, figsize=figure_size)
         self._plot_image(
             orig,
             axes=axes[0],
-            figsize=figsize,
+            figure_size=figure_size,
             render_factor=render_factor,
             display_render_factor=False,
         )
         self._plot_image(
             result,
             axes=axes[1],
-            figsize=figsize,
+            figure_size=figure_size,
             render_factor=render_factor,
             display_render_factor=display_render_factor,
         )
 
-    def _plot_solo(
-        self,
-        figsize: Tuple[int, int],
-        render_factor: int,
-        display_render_factor: bool,
-        result: Image,
-    ):
-        fig, axes = plt.subplots(1, 1, figsize=figsize)
+    def _plot_solo(self,
+                   figure_size: Tuple[int, int],
+                   render_factor: int,
+                   display_render_factor: bool,
+                   result: Image):
+
+        fig, axes = plt.subplots(1, 1, figsize=figure_size)
+
         self._plot_image(
             result,
             axes=axes,
-            figsize=figsize,
+            figure_size=figure_size,
             render_factor=render_factor,
             display_render_factor=display_render_factor,
         )
 
-    def _save_result_image(self, source_path: Path, image: Image, results_dir = None) -> Path:
+    def _save_result_image(self, source_path: Path, result_image: Image, results_dir=None) -> Path:
         if results_dir is None:
             results_dir = Path(self.results_dir)
+
         result_path = results_dir / source_path.name
-        image.save(result_path)
+        result_image.save(result_path)
+
         return result_path
 
-    def get_transformed_image(
-        self, path: Path, render_factor: int = None, post_process: bool = True,
-        watermarked: bool = True,
-    ) -> Image:
+    def get_transformed_image(self,
+                              path: Path,
+                              render_factor:
+                              int = None,
+                              post_process: bool = True,
+                              watermarked: bool = True) -> Image:
         self._clean_mem()
+
         orig_image = self._open_pil_image(path)
-        filtered_image = self.filter.filter(
-            orig_image, orig_image, render_factor=render_factor,post_process=post_process
-        )
+        filtered_image = self.filter.filter(orig_image,
+                                            orig_image,
+                                            render_factor=render_factor,
+                                            post_process=post_process)
 
         if watermarked:
             return get_watermarked(filtered_image)
 
         return filtered_image
 
-    def _plot_image(
-        self,
-        image: Image,
-        render_factor: int,
-        axes: Axes = None,
-        figsize=(20, 20),
-        display_render_factor = False,
-    ):
+    def _plot_image(self,
+                    image: Image,
+                    render_factor: int,
+                    axes: Axes = None,
+                    figure_size=(20, 20),
+                    display_render_factor=False):
+
         if axes is None:
-            _, axes = plt.subplots(figsize=figsize)
+            _, axes = plt.subplots(figsize=figure_size)
+
         axes.imshow(np.asarray(image) / 255)
         axes.axis('off')
+
         if render_factor is not None and display_render_factor:
-            plt.text(
-                10,
-                10,
-                'render_factor: ' + str(render_factor),
-                color='white',
-                backgroundcolor='black',
-            )
+            plt.text(10,
+                     10,
+                     'render_factor: ' + str(render_factor),
+                     color='white',
+                     backgroundcolor='black')
 
     def _get_num_rows_columns(self, num_images: int, max_columns: int) -> Tuple[int, int]:
         columns = min(num_images, max_columns)
         rows = num_images // columns
         rows = rows if rows * columns == num_images else rows + 1
+
         return rows, columns
 
 
 class VideoColorizer:
+
     def __init__(self, vis: ModelImageVisualizer):
         self.vis = vis
-        workfolder = Path('./video')
-        self.source_folder = workfolder / "source"
-        self.bwframes_root = workfolder / "bwframes"
-        self.audio_root = workfolder / "audio"
-        self.colorframes_root = workfolder / "colorframes"
-        self.result_folder = workfolder / "result"
 
-    def _purge_images(self, dir):
-        for f in os.listdir(dir):
-            if re.search('.*?\.jpg', f):
-                os.remove(os.path.join(dir, f))
+        work_folder = Path('./video')
+        self.source_folder = work_folder / 'source'
+        self.bw_frames_root = work_folder / 'bw_frames'
+        self.audio_root = work_folder / 'audio'
+        self.color_frames_root = work_folder / 'color_frames'
+        self.result_folder = work_folder / 'result'
 
-    def _get_ffmpeg_probe(self, path:Path):
+    def _purge_images(self, dir_path):
+        logging.info('Purging *.jpg from %s directory...' % (str(dir_path)))
+
+        for file_path in dir_path.iterdir():
+
+            if not file_path.is_file():
+                continue
+
+            filename, file_extension = os.path.splitext(file_path)
+            if file_extension.lower() == '.jpg':
+                file_path.unlink()
+
+        logging.info('Purge complete.')
+
+    def _get_ffmpeg_probe(self, path: Path):
         try:
             probe = ffmpeg.probe(str(path))
             return probe
-        except ffmpeg.Error as e:
-            logging.error("ffmpeg error: {0}".format(e), exc_info=True)
-            logging.error('stdout:' + e.stdout.decode('UTF-8'))
-            logging.error('stderr:' + e.stderr.decode('UTF-8'))
-            raise e
-        except Exception as e:
-            logging.error('Failed to instantiate ffmpeg.probe.  Details: {0}'.format(e), exc_info=True)   
-            raise e
+        except ffmpeg.Error as ex:
+            logging.error('ffmpeg error: {0}'.format(ex), exc_info=True)
+            logging.error('stdout:' + ex.stdout.decode('UTF-8'))
+            logging.error('stderr:' + ex.stderr.decode('UTF-8'))
+            raise ex
+        except Exception as ex:
+            logging.error('Failed to instantiate ffmpeg.probe.  Details: {0}'.format(ex), exc_info=True)
+            raise ex
 
-    def _get_fps(self, source_path: Path) -> str:
-        probe = self._get_ffmpeg_probe(source_path)
-        stream_data = next(
-            (stream for stream in probe['streams'] if stream['codec_type'] == 'video'),
-            None,
-        )
-        return stream_data['avg_frame_rate']
+    def _get_video_stream_attributes(self, source_local_path: Path) -> dict:
+        probe_result = self._get_ffmpeg_probe(source_local_path)
+        video_streams = [stream
+                         for stream
+                         in probe_result['streams']
+                         if stream['codec_type'] == 'video']
 
-    def _download_video_from_url(self, source_url, source_path: Path):
-        if source_path.exists():
-            source_path.unlink()
+        video_streams_count = len(video_streams)
+        if video_streams_count == 0:
+            raise Exception('no video stream found')
+        elif video_streams_count > 1:
+            raise Exception('multiple video streams found')
 
-        ydl_opts = {
+        video_stream_attributes = video_streams[0]
+        return video_stream_attributes
+
+    def _download_video_from_url(self, source_url, target_path: Path):
+
+        if target_path.exists():
+            target_path.unlink()
+
+        youtube_downloader_options = {
             'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/mp4',
-            'outtmpl': str(source_path),
+            'outtmpl': str(target_path),
             'retries': 30,
             'fragment-retries': 30
         }
-        with youtube_dl.YoutubeDL(ydl_opts) as ydl:
-            ydl.download([source_url])
+        with youtube_dl.YoutubeDL(youtube_downloader_options) as youtube_downloader:
+            youtube_downloader.download([source_url])
 
-    def _extract_raw_frames(self, source_path: Path):
-        bwframes_folder = self.bwframes_root / (source_path.stem)
-        bwframe_path_template = str(bwframes_folder / '%5d.jpg')
-        bwframes_folder.mkdir(parents=True, exist_ok=True)
-        self._purge_images(bwframes_folder)
+    def _extract_raw_frames(self,
+                            source_path: Path,
+                            expected_frame_count: int,
+                            resume: bool = False):
+        source_path_string = str(source_path)
+        bw_frames_folder = self.bw_frames_root / source_path.stem
+        bw_frame_path_template = str(bw_frames_folder / '%5d.jpg')
+        bw_frames_folder.mkdir(parents=True, exist_ok=True)
+
+        if resume:
+            bw_folder_file_count = len([f for f in bw_frames_folder.iterdir() if os.path.isfile(f)])
+            if bw_folder_file_count == expected_frame_count:
+                logging.info('Resume is ON: all raw frames found, skipping extraction of raw frames.')
+                return
+
+            logging.info('Resume is ON: found %s frames but expected %s, proceeding to purge existing frames.' % (bw_folder_file_count, expected_frame_count))
+
+        self._purge_images(bw_frames_folder)
+
+
+        # NOTE: we specify -vsync vfr to prevents frame duplication, more in the link below:
+        #       https://superuser.com/questions/1512575/why-total-frame-count-is-different-in-ffmpeg-than-ffprobe
+        process = (
+            ffmpeg
+            .input(source_path_string)
+            .output(bw_frame_path_template, vsync='vfr', format='image2', vcodec='mjpeg', **{'q:v': '0'})
+            .global_args('-hide_banner')
+            .global_args('-nostats')
+            .global_args('-loglevel', 'error')
+        )
+
+        logging.info('Extracting raw frames (%s frames total)...' % expected_frame_count)
+
+        try:
+            process.run()
+        except ffmpeg.Error as ex:
+            logging.error('ffmpeg error: {0}'.format(ex), exc_info=True)
+            logging.error('stdout:' + ex.stdout.decode('UTF-8'))
+            logging.error('stderr:' + ex.stderr.decode('UTF-8'))
+            raise ex
+        except Exception as ex:
+            logging.error('Error while extracting raw frames from source video. Details: {0}'.format(ex), exc_info=True)
+            raise ex
+
+        bw_folder_file_count = len([f for f in bw_frames_folder.iterdir() if os.path.isfile(f)])
+        logging.info('Extraction complete, %s frames extracted.' % bw_folder_file_count)
+
+    def _colorize_raw_frames(self,
+                             source_path: Path,
+                             render_factor:
+                             int = None,
+                             post_process: bool = True,
+                             watermarked: bool = True,
+                             resume: bool = False):
+
+        bw_frames_folder = self.bw_frames_root / source_path.stem
+        color_frames_folder = self.color_frames_root / source_path.stem
+        color_frames_folder.mkdir(parents=True, exist_ok=True)
+
+        if not resume:
+            self._purge_images(color_frames_folder)
+
+        logging.info('Colorizing frames...')
+
+        all_source_files = [f for f in bw_frames_folder.iterdir() if os.path.isfile(f)]
+        all_source_files = sorted(all_source_files, key=lambda a_file: int(os.path.splitext(a_file.name)[0]))
+
+        if resume:
+            remaining_source_files = [a_file
+                                      for a_file
+                                      in all_source_files
+                                      if not os.path.isfile(color_frames_folder / a_file.name)]
+
+            all_source_file_count = len(all_source_files)
+            remaining_source_file_count = len(remaining_source_files)
+            already_done_file_count = all_source_file_count - remaining_source_file_count
+
+            logging.info('Resume is ON: %s out of %s frames all ready done, %s frames remaining.' % (
+                already_done_file_count,
+                all_source_file_count,
+                remaining_source_file_count))
+        else:
+            remaining_source_files = all_source_files
+
+        for source_file in progress_bar(remaining_source_files):
+            source_filename = source_file.name
+            source_frame_path = bw_frames_folder / source_filename
+            destination_frame_path = color_frames_folder / source_filename
+
+            if os.path.isfile(source_frame_path):
+                color_frame = self.vis.get_transformed_image(source_frame_path,
+                                                             render_factor=render_factor,
+                                                             post_process=post_process,
+                                                             watermarked=watermarked)
+                color_frame.save(str(destination_frame_path))
+
+        logging.info('Colorization complete.')
+
+    def _build_video(self, source_local_path: Path) -> Path:
+
+        logging.info('Building video...')
+
+        colorized_video_path = self.result_folder / (source_local_path.name.replace('.mp4', '_no_audio.mp4'))
+        color_frames_folder = self.color_frames_root / source_local_path.stem
+        color_frames_path_template = str(color_frames_folder / '%5d.jpg')
+
+        colorized_video_path.parent.mkdir(parents=True, exist_ok=True)
+        if colorized_video_path.exists():
+            colorized_video_path.unlink()
+
+        video_stream_attributes = self._get_video_stream_attributes(source_local_path)
+        source_video_fps = video_stream_attributes['avg_frame_rate']
 
         process = (
             ffmpeg
-                .input(str(source_path))
-                .output(str(bwframe_path_template), format='image2', vcodec='mjpeg', **{'q:v':'0'})
-                .global_args('-hide_banner')
-                .global_args('-nostats')
-                .global_args('-loglevel', 'error')
+            .input(color_frames_path_template, format='image2', vcodec='mjpeg', framerate=source_video_fps)
+            .output(str(colorized_video_path), crf=17, vcodec='libx264')
+            .global_args('-hide_banner')
+            .global_args('-nostats')
+            .global_args('-loglevel', 'error')
         )
 
         try:
             process.run()
         except ffmpeg.Error as e:
-            logging.error("ffmpeg error: {0}".format(e), exc_info=True)
+            logging.error('ffmpeg error: {0}'.format(e), exc_info=True)
             logging.error('stdout:' + e.stdout.decode('UTF-8'))
             logging.error('stderr:' + e.stderr.decode('UTF-8'))
             raise e
         except Exception as e:
-            logging.error('Errror while extracting raw frames from source video.  Details: {0}'.format(e), exc_info=True)   
+            logging.error('Error while building output video.  Details: {0}'.format(e), exc_info=True)
             raise e
 
-    def _colorize_raw_frames(
-        self, source_path: Path, render_factor: int = None, post_process: bool = True,
-        watermarked: bool = True,
-    ):
-        colorframes_folder = self.colorframes_root / (source_path.stem)
-        colorframes_folder.mkdir(parents=True, exist_ok=True)
-        self._purge_images(colorframes_folder)
-        bwframes_folder = self.bwframes_root / (source_path.stem)
+        result_path = self.result_folder / source_local_path.name
 
-        for img in progress_bar(os.listdir(str(bwframes_folder))):
-            img_path = bwframes_folder / img
-
-            if os.path.isfile(str(img_path)):
-                color_image = self.vis.get_transformed_image(
-                    str(img_path), render_factor=render_factor, post_process=post_process,watermarked=watermarked
-                )
-                color_image.save(str(colorframes_folder / img))
-
-    def _build_video(self, source_path: Path) -> Path:
-        colorized_path = self.result_folder / (
-            source_path.name.replace('.mp4', '_no_audio.mp4')
-        )
-        colorframes_folder = self.colorframes_root / (source_path.stem)
-        colorframes_path_template = str(colorframes_folder / '%5d.jpg')
-        colorized_path.parent.mkdir(parents=True, exist_ok=True)
-        if colorized_path.exists():
-            colorized_path.unlink()
-        fps = self._get_fps(source_path)
-
-        process = (
-            ffmpeg 
-                .input(str(colorframes_path_template), format='image2', vcodec='mjpeg', framerate=fps) 
-                .output(str(colorized_path), crf=17, vcodec='libx264')
-                .global_args('-hide_banner')
-                .global_args('-nostats')
-                .global_args('-loglevel', 'error')
-        )
-
-        try:
-            process.run()
-        except ffmpeg.Error as e:
-            logging.error("ffmpeg error: {0}".format(e), exc_info=True)
-            logging.error('stdout:' + e.stdout.decode('UTF-8'))
-            logging.error('stderr:' + e.stderr.decode('UTF-8'))
-            raise e
-        except Exception as e:
-            logging.error('Errror while building output video.  Details: {0}'.format(e), exc_info=True)   
-            raise e
-
-        result_path = self.result_folder / source_path.name
         if result_path.exists():
             result_path.unlink()
+
         # making copy of non-audio version in case adding back audio doesn't apply or fails.
-        shutil.copyfile(str(colorized_path), str(result_path))
+        shutil.copyfile(str(colorized_video_path), str(result_path))
 
         # adding back sound here
-        audio_file = Path(str(source_path).replace('.mp4', '.aac'))
+        audio_file = Path(str(source_local_path).replace('.mp4', '.aac'))
         if audio_file.exists():
             audio_file.unlink()
 
-        os.system(
-            'ffmpeg -y -i "'
-            + str(source_path)
-            + '" -vn -acodec copy "'
-            + str(audio_file)
-            + '"'
-            + ' -hide_banner'
-            + ' -nostats'
-            + ' -loglevel error'
-        )
+        os.system('ffmpeg -y -i "%s" -vn -acodec copy "%s" -hide_banner -nostats -loglevel error' % (str(source_local_path), str(audio_file)))
 
         if audio_file.exists():
             os.system(
-                'ffmpeg -y -i "'
-                + str(colorized_path)
-                + '" -i "'
-                + str(audio_file)
-                + '" -shortest -c:v copy -c:a aac -b:a 256k "'
-                + str(result_path)
-                + '"'
-                + ' -hide_banner'
-                + ' -nostats'
-                + ' -loglevel error'
-            )
+                'ffmpeg -y -i "%s" -i "%s" -shortest -c:v copy -c:a aac -b:a 256k "%s" -hide_banner -nostats -loglevel error' % (
+                    str(colorized_video_path),
+                    str(audio_file),
+                    str(result_path)))
+
+        logging.info('Build complete.')
         logging.info('Video created here: ' + str(result_path))
+
         return result_path
 
-    def colorize_from_url(
-        self,
-        source_url,
-        file_name: str,
-        render_factor: int = None,
-        post_process: bool = True,
-        watermarked: bool = True,
+    def colorize_from_uri(self,
+                          source_uri: str,
+                          render_factor: int = None,
+                          watermarked: bool = True,
+                          post_process: bool = True,
+                          resume: bool = False) -> Path:
 
-    ) -> Path:
-        source_path = self.source_folder / file_name
-        self._download_video_from_url(source_url, source_path)
-        return self._colorize_from_path(
-            source_path, render_factor=render_factor, post_process=post_process,watermarked=watermarked
-        )
+        def is_url(x):
+            try:
+                result = urlparse(x)
+                return all([result.scheme, result.netloc])
+            except Exception:
+                return False
 
-    def colorize_from_file_name(
-        self, file_name: str, render_factor: int = None,  watermarked: bool = True, post_process: bool = True,
-    ) -> Path:
-        source_path = self.source_folder / file_name
-        return self._colorize_from_path(
-            source_path, render_factor=render_factor,  post_process=post_process,watermarked=watermarked
-        )
+        logging.info('Colorization starting')
 
-    def _colorize_from_path(
-        self, source_path: Path, render_factor: int = None,  watermarked: bool = True, post_process: bool = True
-    ) -> Path:
-        if not source_path.exists():
-            raise Exception(
-                'Video at path specfied, ' + str(source_path) + ' could not be found.'
-            )
-        self._extract_raw_frames(source_path)
-        self._colorize_raw_frames(
-            source_path, render_factor=render_factor,post_process=post_process,watermarked=watermarked
-        )
-        return self._build_video(source_path)
+        # if source_uri is a URL, download the target file and set filename accordingly.
+        if is_url(source_uri):
+            filename = os.path.basename(urlparse(source_uri).path)
+            source_local_path = self.source_folder / filename
+            self._download_video_from_url(source_uri, source_local_path)
+        else:  # otherwise, source_uri is simply the filename of the source file without the local path.
+            filename = source_uri
+            source_local_path = self.source_folder / filename
+
+        if not source_local_path.exists():
+            raise Exception('video %s could not be found at specified location' % str(source_local_path))
+
+        video_stream_attributes = self._get_video_stream_attributes(source_local_path)
+        source_video_frame_count = int(video_stream_attributes['nb_frames'])
+
+        self._extract_raw_frames(source_local_path,
+                                 source_video_frame_count,
+                                 resume=resume)
+
+        self._colorize_raw_frames(source_local_path,
+                                  render_factor=render_factor,
+                                  post_process=post_process,
+                                  watermarked=watermarked,
+                                  resume=resume)
+
+        result_path = self._build_video(source_local_path)
+
+        logging.info('Colorization complete.')
+
+        return result_path
 
 
 def get_video_colorizer(render_factor: int = 21) -> VideoColorizer:
-    return get_stable_video_colorizer(render_factor=render_factor)
+    logging.info('Initializing colorizer...')
+    stable_video_colorizer = get_stable_video_colorizer(render_factor=render_factor)
+    logging.info('Initialization complete.')
+
+    return stable_video_colorizer
 
 
 def get_artistic_video_colorizer(
@@ -418,8 +523,8 @@ def get_artistic_video_colorizer(
     render_factor: int = 35
 ) -> VideoColorizer:
     learn = gen_inference_deep(root_folder=root_folder, weights_name=weights_name)
-    filtr = MasterFilter([ColorizerFilter(learn=learn)], render_factor=render_factor)
-    vis = ModelImageVisualizer(filtr, results_dir=results_dir)
+    filter_ = MasterFilter([ColorizerFilter(learn=learn)], render_factor=render_factor)
+    vis = ModelImageVisualizer(filter_, results_dir=results_dir)
     return VideoColorizer(vis)
 
 
@@ -430,29 +535,29 @@ def get_stable_video_colorizer(
     render_factor: int = 21
 ) -> VideoColorizer:
     learn = gen_inference_wide(root_folder=root_folder, weights_name=weights_name)
-    filtr = MasterFilter([ColorizerFilter(learn=learn)], render_factor=render_factor)
-    vis = ModelImageVisualizer(filtr, results_dir=results_dir)
+    filter_ = MasterFilter([ColorizerFilter(learn=learn)], render_factor=render_factor)
+    vis = ModelImageVisualizer(filter_, results_dir=results_dir)
     return VideoColorizer(vis)
 
 
-def get_image_colorizer(
-    root_folder: Path = Path('./'), render_factor: int = 35, artistic: bool = True
-) -> ModelImageVisualizer:
+def get_image_colorizer(root_folder: Path = Path('./'),
+                        render_factor: int = 35,
+                        artistic: bool = True) -> ModelImageVisualizer:
     if artistic:
         return get_artistic_image_colorizer(root_folder=root_folder, render_factor=render_factor)
     else:
         return get_stable_image_colorizer(root_folder=root_folder, render_factor=render_factor)
 
 
-def get_stable_image_colorizer(
-    root_folder: Path = Path('./'),
-    weights_name: str = 'ColorizeStable_gen',
-    results_dir='result_images',
-    render_factor: int = 35
-) -> ModelImageVisualizer:
+def get_stable_image_colorizer(root_folder: Path = Path('./'),
+                               weights_name: str = 'ColorizeStable_gen',
+                               results_dir='result_images',
+                               render_factor: int = 35) -> ModelImageVisualizer:
+
     learn = gen_inference_wide(root_folder=root_folder, weights_name=weights_name)
-    filtr = MasterFilter([ColorizerFilter(learn=learn)], render_factor=render_factor)
-    vis = ModelImageVisualizer(filtr, results_dir=results_dir)
+    filter_ = MasterFilter([ColorizerFilter(learn=learn)], render_factor=render_factor)
+    vis = ModelImageVisualizer(filter_, results_dir=results_dir)
+
     return vis
 
 
@@ -463,19 +568,19 @@ def get_artistic_image_colorizer(
     render_factor: int = 35
 ) -> ModelImageVisualizer:
     learn = gen_inference_deep(root_folder=root_folder, weights_name=weights_name)
-    filtr = MasterFilter([ColorizerFilter(learn=learn)], render_factor=render_factor)
-    vis = ModelImageVisualizer(filtr, results_dir=results_dir)
+    filter_ = MasterFilter([ColorizerFilter(learn=learn)], render_factor=render_factor)
+    vis = ModelImageVisualizer(filter_, results_dir=results_dir)
     return vis
 
 
 def show_image_in_notebook(image_path: Path):
-    ipythondisplay.display(ipythonimage(str(image_path)))
+    ipython_display.display(IpythonImage(str(image_path)))
 
 
 def show_video_in_notebook(video_path: Path):
     video = io.open(video_path, 'r+b').read()
     encoded = base64.b64encode(video)
-    ipythondisplay.display(
+    ipython_display.display(
         HTML(
             data='''<video alt="test" autoplay 
                 loop controls style="height: 400px;">

--- a/deoldify/visualize.py
+++ b/deoldify/visualize.py
@@ -19,7 +19,7 @@ from IPython.display import HTML
 from IPython.display import Image as IpythonImage
 
 
-# adapted from https://www.pyimagesearch.com/2016/04/25/watermarking-images-with-opencv-and-python/
+# NOTE: adapted from https://www.pyimagesearch.com/2016/04/25/watermarking-images-with-opencv-and-python/
 def get_watermarked(pil_image: Image) -> Image:
 
     try:
@@ -175,7 +175,10 @@ class ModelImageVisualizer:
             display_render_factor=display_render_factor,
         )
 
-    def _save_result_image(self, source_path: Path, result_image: Image, results_dir=None) -> Path:
+    def _save_result_image(self,
+                           source_path: Path,
+                           result_image: Image,
+                           results_dir=None) -> Path:
         if results_dir is None:
             results_dir = Path(self.results_dir)
 
@@ -312,15 +315,15 @@ class VideoColorizer:
         if resume:
             bw_folder_file_count = len([f for f in bw_frames_folder.iterdir() if os.path.isfile(f)])
             if bw_folder_file_count == expected_frame_count:
-                logging.info('Resume is ON: all raw frames found, skipping extraction of raw frames.')
+                logging.info('Resume set to TRUE: all raw frames found, skipping extraction of raw frames.')
                 return
 
-            logging.info('Resume is ON: found %s frames but expected %s, proceeding to purge existing frames.' % (bw_folder_file_count, expected_frame_count))
+            logging.info('Resume set to TRUE: found %s frames but expected %s, proceeding to purge existing frames.' % (bw_folder_file_count, expected_frame_count))
 
         self._purge_images(bw_frames_folder)
 
 
-        # NOTE: we specify -vsync vfr to prevents frame duplication, more in the link below:
+        # NOTE: we specify "-vsync vfr" to prevent frame duplication, more in the link below:
         #       https://superuser.com/questions/1512575/why-total-frame-count-is-different-in-ffmpeg-than-ffprobe
         process = (
             ffmpeg
@@ -377,7 +380,7 @@ class VideoColorizer:
             remaining_source_file_count = len(remaining_source_files)
             already_done_file_count = all_source_file_count - remaining_source_file_count
 
-            logging.info('Resume is ON: %s out of %s frames all ready done, %s frames remaining.' % (
+            logging.info('Resume set to TRUE: %s out of %s frames all ready done, %s frames remaining.' % (
                 already_done_file_count,
                 all_source_file_count,
                 remaining_source_file_count))
@@ -455,8 +458,7 @@ class VideoColorizer:
                     str(audio_file),
                     str(result_path)))
 
-        logging.info('Build complete.')
-        logging.info('Video created here: ' + str(result_path))
+        logging.info('Build complete, video created here: %s' % str(result_path))
 
         return result_path
 
@@ -516,24 +518,22 @@ def get_video_colorizer(render_factor: int = 21) -> VideoColorizer:
     return stable_video_colorizer
 
 
-def get_artistic_video_colorizer(
-    root_folder: Path = Path('./'),
-    weights_name: str = 'ColorizeArtistic_gen',
-    results_dir='result_images',
-    render_factor: int = 35
-) -> VideoColorizer:
+def get_artistic_video_colorizer(root_folder: Path = Path('./'),
+                                 weights_name: str = 'ColorizeArtistic_gen',
+                                 results_dir='result_images',
+                                 render_factor: int = 35) -> VideoColorizer:
+
     learn = gen_inference_deep(root_folder=root_folder, weights_name=weights_name)
     filter_ = MasterFilter([ColorizerFilter(learn=learn)], render_factor=render_factor)
     vis = ModelImageVisualizer(filter_, results_dir=results_dir)
     return VideoColorizer(vis)
 
 
-def get_stable_video_colorizer(
-    root_folder: Path = Path('./'),
-    weights_name: str = 'ColorizeVideo_gen',
-    results_dir='result_images',
-    render_factor: int = 21
-) -> VideoColorizer:
+def get_stable_video_colorizer(root_folder: Path = Path('./'),
+                               weights_name: str = 'ColorizeVideo_gen',
+                               results_dir='result_images',
+                               render_factor: int = 21) -> VideoColorizer:
+
     learn = gen_inference_wide(root_folder=root_folder, weights_name=weights_name)
     filter_ = MasterFilter([ColorizerFilter(learn=learn)], render_factor=render_factor)
     vis = ModelImageVisualizer(filter_, results_dir=results_dir)
@@ -561,15 +561,15 @@ def get_stable_image_colorizer(root_folder: Path = Path('./'),
     return vis
 
 
-def get_artistic_image_colorizer(
-    root_folder: Path = Path('./'),
-    weights_name: str = 'ColorizeArtistic_gen',
-    results_dir='result_images',
-    render_factor: int = 35
-) -> ModelImageVisualizer:
+def get_artistic_image_colorizer(root_folder: Path = Path('./'),
+                                 weights_name: str = 'ColorizeArtistic_gen',
+                                 results_dir='result_images',
+                                 render_factor: int = 35) -> ModelImageVisualizer:
+
     learn = gen_inference_deep(root_folder=root_folder, weights_name=weights_name)
     filter_ = MasterFilter([ColorizerFilter(learn=learn)], render_factor=render_factor)
     vis = ModelImageVisualizer(filter_, results_dir=results_dir)
+
     return vis
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - pip
 - fastai=1.0.60
 - python=3.10
-- pytorch::pytorch=1.11.0
+- pytorch::pytorch=1.12.0
 - pytorch::torchvision
 - pytorch::torchaudio
 - tensorboardX


### PR DESCRIPTION
1. Initialize global logger with a proper format

2. Bump pytorch to v1.12.0 (from v1.11.0) in order to overcome current dependency incompatibility

3. Lots of styling improvements to make the code more readable (visualize.py & filters.py)

4. Added support for resuming including detection of whether raw frames were already fully extracted (resume is set to True in VideoColorizer notebook example but in general defaults to False)

5. Replace "colorize_from_{url/file_name/path}" with a single "colorize_from_uri" function that detects whether the uri parameter is a URL or not and acts accordingly
 
6. Added logging some messages to indicate progress and output some useful information

7. Updated example in VideoColorizer notebook (note that "watermarked" is now set to False in the example)