### PR TITLE
removed unnecessary ffmpeg requirement - fixes issue #482

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,6 @@ dependencies:
 - jupyterlab
 - pillow>=9.0.0
 - ipywidgets
-- ffmpeg
 - pip:
   - ffmpeg-python
   - opencv-python>=4.2.0.32

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 wandb
 fastai==1.0.60
 tensorboardX>=1.6
-ffmpeg
 ffmpeg-python
 yt-dlp
 jupyterlab


### PR DESCRIPTION
## Description

This pull request removes a redundant ffmpeg depedency.

## Related Issue

Fixes #482

## Changes

- removed `ffmpeg` from requirements.txt
- removed `ffmpeg` from environment.yml

## Details

The `ffmpeg` package includes the following modules:
- audio
- images
- stream
- video

None of these modules are called upon in the `DeOldify` code. It also includes a blank `__init__.py` that is overridden by the `ffmpeg-python` dependency referenced in [issue #482](https://github.com/jantic/DeOldify/issues/482).

The `DeOldify` code uses the following ffmpeg calls that are all resolved with the `ffmpeg-python` dependecy.

```python
import ffmpeg
```
```python
probe = ffmpeg.probe(str(path))
```
```python
except ffmpeg.Error as e:
```
```python
process = (
    ffmpeg
        .input(str(source_path))
        .output(str(bwframe_path_template), format='image2', vcodec='mjpeg', **{'q:v':'0'})
        .global_args('-hide_banner')
        .global_args('-nostats')
        .global_args('-loglevel', 'error')
)
```
<br>
<br>

It also includes other direct system calls which don't rely on either dependency:
```python
os.system(
    'ffmpeg -y -i "'
    + str(source_path)
    + '" -vn -acodec copy "'
    + str(audio_file)
    + '"'
    + ' -hide_banner'
    + ' -nostats'
    + ' -loglevel error'
)
```

## Note:
Both ffmpeg dependencies rely on the ffmpeg binary being globally available via the `PATH` env variable.

## Testing
Tested with the `ColorizeVideo_gen.pth` model and the following code using only the `ffmpeg-python` dependency:
```python
from deoldify import device
from deoldify.device_id import DeviceId
#choices:  CPU, GPU0...GPU7
device.set(device=DeviceId.GPU0)

from deoldify.visualize import *
plt.style.use('dark_background')
import warnings
warnings.filterwarnings("ignore", category=UserWarning, message=".*?Your .*? set is empty.*?")

colorizer = get_video_colorizer()
colorizer.colorize_from_file_name("mytestfile.mp4")
```
`bwframes`, `colorframes`, and `result` were all rendered successfully.